### PR TITLE
Fix input when typing pokemon name MW

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,10 @@ class App extends Component {
   }
 
   handleChange = (event) => {
-    this.setState({ userValue: event.target.value });
+    this.setState({
+      userValue: event.target.value,
+      selectedIndex: this.state.allPokemon.findIndex((el) => el.name === event.target.value)
+    });    
   };
 
   handleInputClick = async (selectedName, index) => {


### PR DESCRIPTION
I've added the functionality in the case a user 'types' in to the input field the pokemon name instead of clicking it's name in the dropdown menu.
Before that, it was throwing an error upon clicking the search button.
Please review these edits.
(please let me know before you merge, I wanted to check something whilst doing the merge as discussed with @MrRawrgers last night...)
